### PR TITLE
Don't stage cargo, trims it down to just 1 MB

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,9 +69,6 @@ parts:
     plugin: rust
     build-packages:
       - cargo
-    stage-packages:
-      - cargo
-      
     override-pull: |
       craftctl default
       craftctl set version="$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"       


### PR DESCRIPTION
I don't think we need to stage any dependencies here, this shaves 252M off the resulting snap